### PR TITLE
fix: make default boostrap MVS

### DIFF
--- a/src/mother/ml/models/m_catboost.py
+++ b/src/mother/ml/models/m_catboost.py
@@ -421,7 +421,7 @@ class CatboostRegressorMother(CatBoostRegressor, _CatboostModelMotherBase, _Catb
         return models_utils.add_prefix_to_dict_keys(
             {
                 "learning_rate": 0.03,
-                "bootstrap_type": "Bayesian",
+                "bootstrap_type": "MVS",
                 "random_strength": 1,
                 "grow_policy": "SymmetricTree",
                 "boosting_type": "Plain",
@@ -906,7 +906,7 @@ class CatboostGaussianProcessRegressorMother(CatBoostRegressor, _CatboostModelMo
         # Use the same defaults as CatboostRegressorMother for consistency
         base_defaults = {
             "learning_rate": 0.03,
-            "bootstrap_type": "Bayesian",
+            "bootstrap_type": "MVS",
             "random_strength": 1,
             "grow_policy": "SymmetricTree",
             "boosting_type": "Plain",
@@ -1259,7 +1259,7 @@ class CatboostClassifierMother(CatBoostClassifier, _CatboostModelMotherBase, _Ca
         return models_utils.add_prefix_to_dict_keys(
             {
                 "learning_rate": 0.03,
-                "bootstrap_type": "Bayesian",
+                "bootstrap_type": "MVS",
                 "random_strength": 1,
                 "grow_policy": "SymmetricTree",
                 "boosting_type": "Plain",

--- a/test/unit/test_catboost_clf_uncertainty.py
+++ b/test/unit/test_catboost_clf_uncertainty.py
@@ -203,7 +203,7 @@ class TestCatboostClassifierModels(unittest.TestCase):
         default_params = model.default_parameters()
 
         self.assertAlmostEqual(default_params["learning_rate"], 0.03)
-        self.assertEqual(default_params["bootstrap_type"], "Bayesian")
+        self.assertEqual(default_params["bootstrap_type"], "MVS")
         self.assertEqual(default_params["random_strength"], 1)
         self.assertEqual(default_params["grow_policy"], "SymmetricTree")
         self.assertEqual(default_params["boosting_type"], "Plain")


### PR DESCRIPTION
The default bootstrap for catboost optimization using Optuna shoule be MVS, was not clear from the documentation if Bayesian or MVS, but generated some catboost models to check.