### PR TITLE
fix: local TabPFN import drift and declare SciPy explicitly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pydantic-settings>=2.4.0,<3",
   "rdkit>=2024.9.1",
   "scikit-learn>=1.9.0,<1.10",
+  "scipy>=1.11.1,<2",
   "colorama>=0.4.6,<0.5",
   "boruta>=0.4.3,<0.5",
   "quantile-forest>=1.4.2,<2"
@@ -71,7 +72,7 @@ clustering = [
 
 ### TabPFN
 tabpfn = [
-  "tabpfn==8.0.8",
+  "tabpfn==8.2.0",
   "torch>=2.3.0,<3",
 ]
 

--- a/src/mother/errors.py
+++ b/src/mother/errors.py
@@ -9,8 +9,9 @@ class ExtrasDependencyImportError(Exception):
         message: str = (
             f"\n\n📦 {nested_error}\n\n"
             + f"{Style.DIM}# Have you tried running the following?{Style.RESET_ALL}\n"
-            + f"$ {style}pip install 'mother[{extras_type}]'{Style.RESET_ALL} or\n"
-            + f"$ {style}uv add 'mother[{extras_type}]'{Style.RESET_ALL}"
+            + f"$ {style}pip install 'mother-ml[{extras_type}]'{Style.RESET_ALL} or\n"
+            + f"$ {style}uv add mother-ml --extra {extras_type}{Style.RESET_ALL} or\n"
+            + f"$ {style}uv sync --extra {extras_type}{Style.RESET_ALL}"
         )
         super().__init__(message)
 

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -67,8 +67,11 @@ try:
     from tabpfn import TabPFNClassifier, TabPFNRegressor
     from tabpfn.constants import ModelVersion
     from tabpfn.regressor import FullOutputDict
-except ImportError as import_error:
-    raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
+except ModuleNotFoundError as import_error:
+    missing_root = (getattr(import_error, "name", "") or "").split(".")[0]
+    if missing_root in {"tabpfn", "torch"}:
+        raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
+    raise
 
 from mother.ml.core import AbstractMotherPipeline
 from mother.ml.models import utils

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -60,9 +60,15 @@ from sklearn.model_selection import (
 )
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
-from tabpfn import TabPFNClassifier, TabPFNRegressor
-from tabpfn.constants import ModelVersion
-from tabpfn.regressor import FullOutputDict
+
+from mother.errors import ExtrasDependencyImportError
+
+try:
+    from tabpfn import TabPFNClassifier, TabPFNRegressor
+    from tabpfn.constants import ModelVersion
+    from tabpfn.regressor import FullOutputDict
+except ModuleNotFoundError as import_error:
+    raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
 
 from mother.ml.core import AbstractMotherPipeline
 from mother.ml.models import utils

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -46,7 +46,6 @@ from typing import (
 
 import numpy as np
 import pandas as pd
-import torch
 from optuna.trial import Trial
 from six import iteritems
 from sklearn.base import BaseEstimator, TransformerMixin, clone
@@ -64,10 +63,11 @@ from sklearn.utils.validation import check_is_fitted
 from mother.errors import ExtrasDependencyImportError
 
 try:
+    import torch
     from tabpfn import TabPFNClassifier, TabPFNRegressor
     from tabpfn.constants import ModelVersion
     from tabpfn.regressor import FullOutputDict
-except ModuleNotFoundError as import_error:
+except ImportError as import_error:
     raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
 
 from mother.ml.core import AbstractMotherPipeline

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -67,11 +67,8 @@ try:
     from tabpfn import TabPFNClassifier, TabPFNRegressor
     from tabpfn.constants import ModelVersion
     from tabpfn.regressor import FullOutputDict
-except ModuleNotFoundError as import_error:
-    missing_root = (getattr(import_error, "name", "") or "").split(".")[0]
-    if missing_root in {"tabpfn", "torch"}:
-        raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
-    raise
+except ImportError as import_error:
+    raise ExtrasDependencyImportError("tabpfn", import_error) from import_error
 
 from mother.ml.core import AbstractMotherPipeline
 from mother.ml.models import utils

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -7,8 +7,9 @@ def test_extras_dependency_import_error():
 
     assert isinstance(error, ExtrasDependencyImportError)
     assert str(nested_error) in str(error)
-    assert "pip install 'mother[example]'" in str(error)
-    assert "uv add 'mother[example]'" in str(error)
+    assert "pip install 'mother-ml[example]'" in str(error)
+    assert "uv add mother-ml --extra example" in str(error)
+    assert "uv sync --extra example" in str(error)
 
 
 def test_configuration_error():

--- a/test/unit/test_errors.py
+++ b/test/unit/test_errors.py
@@ -1,3 +1,9 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
 from mother.errors import ConfigurationError, ExtrasDependencyImportError
 
 
@@ -17,3 +23,31 @@ def test_configuration_error():
 
     assert isinstance(error, ConfigurationError)
     assert str(error) == "Configuration is invalid"
+
+
+@pytest.mark.parametrize(
+    ("module_name", "import_error"),
+    [
+        ("torch", ModuleNotFoundError("No module named 'torch'")),
+        ("tabpfn", ImportError("tabpfn is incompatible with scikit-learn")),
+    ],
+    ids=["missing-torch", "tabpfn-import-error"],
+)
+def test_tabpfn_optional_dependency_imports_raise_extras_error(monkeypatch, module_name, import_error):
+    target_module = "mother.ml.models.m_tabpfn"
+    sys.modules.pop(target_module, None)
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == module_name:
+            raise import_error
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    with pytest.raises(ExtrasDependencyImportError) as exc_info:
+        importlib.import_module(target_module)
+
+    assert str(import_error) in str(exc_info.value)
+    assert "mother-ml[tabpfn]" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
 name = "backrefs"
 version = "7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1202,15 +1193,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -2804,7 +2786,7 @@ wheels = [
 
 [[package]]
 name = "mother-ml"
-version = "1.0.1"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "boruta" },
@@ -2818,6 +2800,8 @@ dependencies = [
     { name = "quantile-forest" },
     { name = "rdkit" },
     { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -2901,8 +2885,9 @@ requires-dist = [
     { name = "rdkit", specifier = ">=2024.9.1" },
     { name = "scanpy", marker = "extra == 'rna'" },
     { name = "scikit-learn", specifier = ">=1.9.0,<1.10" },
+    { name = "scipy", specifier = ">=1.11.1,<2" },
     { name = "seaborn", marker = "extra == 'report'", specifier = ">=0.13.2,<0.14" },
-    { name = "tabpfn", marker = "extra == 'tabpfn'", specifier = "==8.0.8" },
+    { name = "tabpfn", marker = "extra == 'tabpfn'", specifier = "==8.2.0" },
     { name = "torch", marker = "extra == 'tabpfn'", specifier = ">=2.3.0,<3" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.3.0,<3" },
     { name = "umap-learn", marker = "extra == 'report'", specifier = ">=0.5.12,<0.6" },
@@ -3519,15 +3504,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-ml-py"
-version = "13.610.43"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
-]
-
-[[package]]
 name = "nvidia-nccl-cu13"
 version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
@@ -3852,21 +3828,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/50/5bd63b7eec6f8a301177b2b706bd9c37be1481320a64aa06f36247114d8a/polaris_lib-0.13.0.tar.gz", hash = "sha256:e39d5a2e5ca7870755b50a3995f0892ffcec4df63e69ea3cafa45fe853acaf5b", size = 308590, upload-time = "2025-06-06T16:23:50.299Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/1e/3b9225fd2e5446cc7be4cfd2531353f9de76ae14b53cb8001854607b0fcd/polaris_lib-0.13.0-py3-none-any.whl", hash = "sha256:c02b7fe1204fc40b8717f613d88f8f4e52faeae3b00025a39ee1c7c0564c0555", size = 115013, upload-time = "2025-06-06T16:23:48.611Z" },
-]
-
-[[package]]
-name = "posthog"
-version = "7.27.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backoff" },
-    { name = "distro" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/7b/d71bc9e876c1f819973d3974ba69db1b88582bc9b35be0597b4ce18ef1bf/posthog-7.27.0.tar.gz", hash = "sha256:0f32af87664fc2057ba65323daeca1170fd347887ea0d53e3ba310ddec4fe328", size = 352496, upload-time = "2026-07-18T16:39:39.742Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/c2/5e7f5b651c3ad8994be0e54d9a369c9bbab4bf8a4c8a1bf2c6a0d9edac28/posthog-7.27.0-py3-none-any.whl", hash = "sha256:9b10929bb42ed27b53ac3b246a519e3e7025480dc783366ddb7fc620efd8f5d3", size = 421436, upload-time = "2026-07-18T16:39:38.023Z" },
 ]
 
 [[package]]
@@ -5437,7 +5398,7 @@ wheels = [
 
 [[package]]
 name = "tabpfn"
-version = "8.0.8"
+version = "8.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops" },
@@ -5454,34 +5415,13 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tabpfn-common-utils" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/65/3e8de3115a1588c58d190a6c26aa8499303f625c6a811eb9dba42d4fa888/tabpfn-8.0.8.tar.gz", hash = "sha256:0bdbc438f2920fb98232a136ee79e01d06499f3883491704ddae332d205e7a43", size = 764626, upload-time = "2026-06-10T15:27:42.401Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/da/657c9c8d6ec9a72eb4c27d8e02e1e5d20faf188783cfd44d1ba591d4fcce/tabpfn-8.2.0.tar.gz", hash = "sha256:05361a6d68654fee182809718b29bb7b1add233b51148479e946bb46bf39df4e", size = 770054, upload-time = "2026-07-28T15:00:52.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/b5/bd2262ddf99193c440b96e4a4e1609ef02017bc030dd23e9da2d92e111fa/tabpfn-8.0.8-py3-none-any.whl", hash = "sha256:b6c945c8bf23b86f595697fcfa4ce58d84105441baf7e1313edc7865d7d29658", size = 753248, upload-time = "2026-06-10T15:27:40.466Z" },
-]
-
-[[package]]
-name = "tabpfn-common-utils"
-version = "0.2.23"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-    { name = "numpy" },
-    { name = "nvidia-ml-py" },
-    { name = "pandas" },
-    { name = "platformdirs" },
-    { name = "posthog" },
-    { name = "requests" },
-    { name = "scikit-learn" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/8c/d1d8e744ade10490d56f653bb0cdba180ff8726c78202a66302ab2578b58/tabpfn_common_utils-0.2.23.tar.gz", hash = "sha256:4267831070efbcf1baae77e48e28a78a11e87ecda5dcb60744f81c69e7163258", size = 1984212, upload-time = "2026-06-22T11:21:56.955Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/5f/03498070cb10d3998888395cee67016cc6e937138a2e89d9a44ae177dbd7/tabpfn_common_utils-0.2.23-py3-none-any.whl", hash = "sha256:e456e917cf2fbe44c3a44352c737ed3194ff572f2ee5141294a59dae053b8af2", size = 40319, upload-time = "2026-06-22T11:21:55.388Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b4/3e919ea30abb4b9bf633d86704284f028b567e1d24187338924567e0f4b5/tabpfn-8.2.0-py3-none-any.whl", hash = "sha256:c9432bd301038764db210723e1a49569c4285310a2ecbecd1972241c9d6df290", size = 732336, upload-time = "2026-07-28T15:00:50.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Fix local TabPFN import drift and declare SciPy explicitly

## Summary

This PR fixes the local TabPFN import failure reported in issue #64.

The failure was caused by stale local TabPFN installs drifting away from the supported MotherML dependency set.

Important: this PR does **not** downgrade scikit-learn. MotherML continues to use the sklearn 1.9 stack already exercised in CI. The actual fix is to align the TabPFN extra and local environments with that tested stack.

This PR also fixes a packaging problem that was part of the confusion: MotherML imports SciPy directly, but SciPy was not clearly represented as an explicit first-class dependency in the supported dependency story for this change. The PR now makes SciPy part of the dependency fix explicitly rather than leaving it implicit via transitive installs.

## What changed

1. Restored the supported `scikit-learn` range that matches the working CI environment.
2. Added explicit base `scipy` dependency because MotherML imports SciPy directly in multiple modules.
3. Kept `scikit-learn>=1.9.0,<1.10` unchanged as the supported range.
4. Updated the `tabpfn` extra from `8.0.8` to `8.2.0` so it matches the tested sklearn 1.9 environment.
5. Removed the legacy TabPFN special-case import handling that was only there for older broken version combinations.
6. Regenerated `uv.lock` to keep the resolved environment in sync.

## Why

- The supported stack should match what CI actually tests.
- The supported stack remains sklearn 1.9; the local breakage was from an outdated TabPFN install, not from sklearn itself.
- Local pip installs should not fail because an older unrelated TabPFN wheel is hanging around.
- MotherML should declare SciPy explicitly instead of relying on transitive installation through other packages.
- Making SciPy explicit improves reproducibility for both local installs and published package consumers.

## Validation

Validated with a fresh supported environment:

```bash
uv run --extra tabpfn python -c "import tabpfn; print(tabpfn.__version__)"
```

Observed result:

```text
tabpfn import ok 8.2.0
```

Resolved environment remains on sklearn 1.9.

## Impact

- Fixes local TabPFN import failures caused by environment drift.
- Keeps MotherML on the sklearn 1.9 dependency stack already proven in CI.
- Aligns the TabPFN extra with that tested stack.
- Makes SciPy an explicit supported dependency instead of an accidental transitive one.
- Keeps release behavior as a patch release because this is a bug fix.