### PR TITLE
Fix use count based fp

### DIFF
--- a/mkdocs/docs/development/dev.md
+++ b/mkdocs/docs/development/dev.md
@@ -254,7 +254,7 @@ The semantic release configuration is defined in `pyproject.toml`:
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 build_command = "uv build"
-upload_to_release = true
+upload_to_vcs_release = true
 
 [tool.semantic_release.changelog]
 mode = "update"
@@ -280,14 +280,11 @@ Releases are automatically triggered when commits are pushed to the `main` branc
 While releases are automated, you can manually trigger a release:
 
 ```bash
-# Dry run to see what would happen
-uv run semantic-release version --no-push
+# Print the next version without changing files
+uv run semantic-release version --print
 
 # Generate changelog only
 uv run semantic-release changelog
-
-# Print current version
-uv run semantic-release version --print
 ```
 
 ### Best Practices

--- a/mkdocs/docs/feature_generation.md
+++ b/mkdocs/docs/feature_generation.md
@@ -31,12 +31,12 @@ for k, v in Descriptors.descList:
 
     #### Binary vs. Count Fingerprints
 
-    By default, fingerprints are generated as **binary** vectors — each bit is either `0` (substructure absent) or `1` (substructure present). You can switch to **count-based** fingerprints by setting `use_counts=True`, which records ***how many times*** each substructure occurs in the molecule. Count fingerprints can improve model performance when the frequency of substructures is informative.
+    By default, `FingerprintsGeneric` and `MorganFingerprints` generate **count-based** vectors, which record ***how many times*** each substructure occurs in a molecule. Count fingerprints can improve model performance when substructure frequency is informative. Set `use_counts=False` to generate a binary vector, where each bit is either `0` (substructure absent) or `1` (substructure present).
 
     | Mode | Parameter | Output values | Use case |
     |------|-----------|---------------|----------|
-    | Binary (default) | `use_counts=False` | 0 or 1 | General-purpose fingerprinting |
-    | Count | `use_counts=True` | 0, 1, 2, … | When substructure frequency matters |
+    | Count (default) | `use_counts=True` | 0, 1, 2, ... | When substructure frequency matters |
+    | Binary | `use_counts=False` | 0 or 1 | When only substructure presence matters |
 
     The `use_counts` parameter is available on both `FingerprintsGeneric` and the `MorganFingerprints` convenience class:
 
@@ -46,17 +46,19 @@ from mother.feature_generation import FingerprintsGeneric, MorganFingerprints
 
 molecule_objects = [Chem.MolFromSmiles(smi) for smi in ["CCO", "CCN", "c1ccccc1"]]
 
-# Count-based Morgan fingerprints via the convenience class
-morgan_counts = MorganFingerprints(radius=2, fpSize=1024, use_counts=True)
+# Count-based Morgan fingerprints are the default
+morgan_counts = MorganFingerprints(radius=2, fpSize=2048)
 features = morgan_counts.fit_transform(molecule_objects)
 
 # Count-based fingerprints via the generic class (works with any supported fp_type)
 fp_counts = FingerprintsGeneric(
     fp_type="AtomPairFP",
     parameters={"fpSize": 2048},
-    use_counts=True,
 )
 features = fp_counts.fit_transform(molecule_objects)
+
+# Opt in to binary Morgan fingerprints
+morgan_binary = MorganFingerprints(radius=2, fpSize=2048, use_counts=False)
 ```
 
     !!! note
@@ -86,10 +88,12 @@ from mother.feature_generation import ChemicalDescriptors, MorganFingerprints
 
 molecule_objects = [Chem.MolFromSmiles(smi) for smi in ["CCO", "CCN", "c1ccccc1"]]
 
-feature_generator = FeatureUnion([
-    ("descriptors", ChemicalDescriptors(descriptor_list=["MolWt", "MolLogP"])),
-    ("morgan_fp", MorganFingerprints(radius=2, fpSize=1024)),
-])
+feature_generator = FeatureUnion(
+    [
+        ("descriptors", ChemicalDescriptors(descriptor_list=["MolWt", "MolLogP"])),
+        ("morgan_fp", MorganFingerprints(radius=2, fpSize=2048)),
+    ]
+)
 features = feature_generator.fit_transform(molecule_objects)
 ```
 

--- a/src/mother/feature_generation/config.py
+++ b/src/mother/feature_generation/config.py
@@ -139,7 +139,7 @@ class FeatureGenerationConfig(BaseModel):
     fingerprints: List[Dict[str, Any]] = Field(default=[], description="List of fingerprint generator settings")
     maccs: bool = Field(default=False, description="Flag if maccs fingerprints should be generated")
     chemical_descriptors: Optional[ChemicalDescriptorsParams] = Field(default=None)
-    use_counts: bool = Field(default=False, description="Whether to use count fingerprints")
+    use_counts: bool = Field(default=True, description="Whether to use count fingerprints")
 
     @field_validator("fingerprints", mode="before")
     @classmethod

--- a/src/mother/feature_generation/core.py
+++ b/src/mother/feature_generation/core.py
@@ -64,7 +64,7 @@ class FingerprintsGeneric(BaseEstimator, TransformerMixin, _TransformOnlyValidMo
     the type and configuration of the fingerprint is determined by the parameters
     """
 
-    def __init__(self, fp_type: str, parameters: dict, use_counts: bool = False) -> None:
+    def __init__(self, fp_type: str, parameters: dict, use_counts: bool = True) -> None:
         self.fp_type: str = fp_type
         self.parameters: dict = parameters
         self.use_counts: bool = use_counts
@@ -119,7 +119,7 @@ class FingerprintsGeneric(BaseEstimator, TransformerMixin, _TransformOnlyValidMo
 
 class MorganFingerprints(FingerprintsGeneric):
     def __init__(
-        self, radius: int = 2, fpSize=1024, include_chirality: bool = False, use_counts: bool = False, **kwargs
+        self, radius: int = 2, fpSize=2048, include_chirality: bool = False, use_counts: bool = True, **kwargs
     ) -> None:
         super().__init__(
             "MorganFP",

--- a/src/mother/feature_generation/core.py
+++ b/src/mother/feature_generation/core.py
@@ -119,7 +119,7 @@ class FingerprintsGeneric(BaseEstimator, TransformerMixin, _TransformOnlyValidMo
 
 class MorganFingerprints(FingerprintsGeneric):
     def __init__(
-        self, radius: int = 2, fpSize=2048, include_chirality: bool = False, use_counts: bool = True, **kwargs
+        self, radius: int = 2, fpSize: int = 2048, include_chirality: bool = False, use_counts: bool = True, **kwargs
     ) -> None:
         super().__init__(
             "MorganFP",

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -218,6 +218,7 @@ class TabPFNRegressorMother(TabPFNRegressor, _TabPFNHyperParams):
         #   TabPFNRegressor.create_default_for_version(ModelVersion.V2)
         if "model_path" not in kwargs:
             kwargs["model_path"] = TabPFNRegressor.create_default_for_version(ModelVersion.V2).model_path
+        kwargs.setdefault("inference_precision", torch.float32)
 
         for key, val in self.default_parameters().items():
             if key not in list(kwargs):
@@ -381,6 +382,7 @@ class TabPFNClassifierMother(TabPFNClassifier, _TabPFNHyperParams):
         #   TabPFNClassifier.create_default_for_version(ModelVersion.V2)
         if "model_path" not in kwargs:
             kwargs["model_path"] = TabPFNClassifier.create_default_for_version(ModelVersion.V2).model_path
+        kwargs.setdefault("inference_precision", torch.float32)
 
         for key, val in self.default_parameters().items():
             if key not in list(kwargs):

--- a/src/mother/ml/models/m_tabpfn.py
+++ b/src/mother/ml/models/m_tabpfn.py
@@ -218,7 +218,6 @@ class TabPFNRegressorMother(TabPFNRegressor, _TabPFNHyperParams):
         #   TabPFNRegressor.create_default_for_version(ModelVersion.V2)
         if "model_path" not in kwargs:
             kwargs["model_path"] = TabPFNRegressor.create_default_for_version(ModelVersion.V2).model_path
-        kwargs.setdefault("inference_precision", torch.float32)
 
         for key, val in self.default_parameters().items():
             if key not in list(kwargs):
@@ -382,7 +381,6 @@ class TabPFNClassifierMother(TabPFNClassifier, _TabPFNHyperParams):
         #   TabPFNClassifier.create_default_for_version(ModelVersion.V2)
         if "model_path" not in kwargs:
             kwargs["model_path"] = TabPFNClassifier.create_default_for_version(ModelVersion.V2).model_path
-        kwargs.setdefault("inference_precision", torch.float32)
 
         for key, val in self.default_parameters().items():
             if key not in list(kwargs):

--- a/test/unit/test_use_counts.py
+++ b/test/unit/test_use_counts.py
@@ -125,7 +125,7 @@ class TestUseCountsMorganFingerprints:
 
     def test_morgan_count_default(self, mols_with_repeated_substructures):
         """MorganFingerprints with default use_counts=True should produce count output."""
-        fg = MorganFingerprints(radius=2, fpSize=1024)
+        fg = MorganFingerprints(radius=2, fpSize=2048)
         fg.fit()
         result = fg.transform(mols_with_repeated_substructures)
 
@@ -133,7 +133,7 @@ class TestUseCountsMorganFingerprints:
 
     def test_morgan_count_mode(self, mols_with_repeated_substructures):
         """RED if use_counts not wired through MorganFingerprints: should produce counts > 1."""
-        fg = MorganFingerprints(radius=2, fpSize=1024, use_counts=True)
+        fg = MorganFingerprints(radius=2, fpSize=2048, use_counts=True)
         fg.fit()
         result = fg.transform(mols_with_repeated_substructures)
 
@@ -142,7 +142,7 @@ class TestUseCountsMorganFingerprints:
 
     def test_morgan_use_counts_preserved_after_set_params(self, mols_with_repeated_substructures):
         """use_counts should persist after set_params on other parameters."""
-        fg = MorganFingerprints(radius=2, fpSize=1024, use_counts=True)
+        fg = MorganFingerprints(radius=2, fpSize=2048, use_counts=True)
         fg.set_params(radius=3)
         fg.fit()
         result = fg.transform(mols_with_repeated_substructures)
@@ -152,7 +152,7 @@ class TestUseCountsMorganFingerprints:
 
     def test_morgan_use_counts_toggled_via_set_params(self, mols_with_repeated_substructures):
         """RED if use_counts isn't a proper sklearn param: set_params should toggle it."""
-        fg = MorganFingerprints(radius=2, fpSize=1024, use_counts=False)
+        fg = MorganFingerprints(radius=2, fpSize=2048, use_counts=False)
         fg.set_params(use_counts=True)
         fg.fit()
         result = fg.transform(mols_with_repeated_substructures)
@@ -164,7 +164,7 @@ class TestUseCountsMorganFingerprints:
         """sklearn.clone should preserve use_counts parameter."""
         from sklearn.base import clone
 
-        fg = MorganFingerprints(radius=2, fpSize=1024, use_counts=True)
+        fg = MorganFingerprints(radius=2, fpSize=2048, use_counts=True)
         fg_cloned = clone(fg)
 
         assert fg_cloned.use_counts is True
@@ -172,7 +172,7 @@ class TestUseCountsMorganFingerprints:
 
     def test_morgan_get_params_includes_use_counts(self):
         """use_counts should be visible in get_params()."""
-        fg = MorganFingerprints(radius=2, fpSize=1024, use_counts=True)
+        fg = MorganFingerprints(radius=2, fpSize=2048, use_counts=True)
         params = fg.get_params()
         assert "use_counts" in params
         assert params["use_counts"] is True

--- a/test/unit/test_use_counts.py
+++ b/test/unit/test_use_counts.py
@@ -87,13 +87,13 @@ class TestUseCountsFingerprintsGeneric:
             "Count and binary fingerprints should produce different outputs"
         )
 
-    def test_use_counts_default_is_false(self):
-        """RED if default changed: use_counts should default to False."""
+    def test_use_counts_default_is_true(self):
+        """use_counts should default to True."""
         fg = FingerprintsGeneric(
             fp_type="MorganFP",
             parameters={"radius": 2, "fpSize": 2048},
         )
-        assert fg.use_counts is False
+        assert fg.use_counts is True
 
     def test_output_shape_consistent(self, mols_with_repeated_substructures):
         """Both modes should produce the same output shape."""
@@ -123,14 +123,13 @@ class TestUseCountsFingerprintsGeneric:
 class TestUseCountsMorganFingerprints:
     """Tests for use_counts on the MorganFingerprints convenience class."""
 
-    def test_morgan_binary_default(self, mols_with_repeated_substructures):
-        """MorganFingerprints with default use_counts=False should produce binary output."""
+    def test_morgan_count_default(self, mols_with_repeated_substructures):
+        """MorganFingerprints with default use_counts=True should produce count output."""
         fg = MorganFingerprints(radius=2, fpSize=1024)
         fg.fit()
         result = fg.transform(mols_with_repeated_substructures)
 
-        unique_values = np.unique(result[~np.isnan(result)])
-        assert set(unique_values).issubset({0, 1})
+        assert np.nanmax(result) > 1
 
     def test_morgan_count_mode(self, mols_with_repeated_substructures):
         """RED if use_counts not wired through MorganFingerprints: should produce counts > 1."""

--- a/uv.lock
+++ b/uv.lock
@@ -773,6 +773,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colour"
+version = "0.1.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/d4/5911a7618acddc3f594ddf144ecd8a03c29074a540f4494670ad8f153efe/colour-0.1.5.tar.gz", hash = "sha256:af20120fefd2afede8b001fbef2ea9da70ad7d49fafdb6489025dae8745c3aee", size = 24776, upload-time = "2017-11-19T23:20:08.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/46/e81907704ab203206769dee1385dc77e1407576ff8f50a0681d0a6b541be/colour-0.1.5-py2.py3-none-any.whl", hash = "sha256:33f6db9d564fadc16e59921a56999b79571160ce09916303d35346dddc17978c", size = 23772, upload-time = "2017-11-19T23:20:04.56Z" },
+]
+
+[[package]]
 name = "comm"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1483,6 +1492,20 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "galois"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/84/996f1c4a7e8fe973a7f8e4d7901e125a91d0abb62615e35076ff47e9383a/galois-0.4.11.tar.gz", hash = "sha256:f5055546c4b39d1e36decae9d4f21f3d66d9c6c7c9aec39189cb5d2284e9022f", size = 7402587, upload-time = "2026-05-02T18:21:28.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/dc69acbd34bde07b9dee9f9f88d7ce61ff97fd99d6d576d72d2db1461349/galois-0.4.11-py3-none-any.whl", hash = "sha256:d2e12a2b7fd44b108cc15d7de27dabcb8a98a556ea2c69c94fe695139629d9aa", size = 4197346, upload-time = "2026-05-02T18:21:26.868Z" },
 ]
 
 [[package]]
@@ -2786,7 +2809,7 @@ wheels = [
 
 [[package]]
 name = "mother-ml"
-version = "1.0.4"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "boruta" },
@@ -2821,6 +2844,11 @@ rna = [
     { name = "anndata" },
     { name = "scanpy", version = "1.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scanpy", version = "1.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+tabicl = [
+    { name = "matplotlib" },
+    { name = "tabicl", extra = ["shap"] },
+    { name = "torch" },
 ]
 tabpfn = [
     { name = "tabpfn" },
@@ -2876,6 +2904,7 @@ requires-dist = [
     { name = "kmedoids", marker = "extra == 'clustering'", specifier = ">=0.5.3.1,<0.6" },
     { name = "leidenalg", marker = "extra == 'report'", specifier = ">=0.10.2,<0.11" },
     { name = "matplotlib", marker = "extra == 'report'", specifier = ">3.7.0" },
+    { name = "matplotlib", marker = "extra == 'tabicl'", specifier = ">3.7.0" },
     { name = "numpy", specifier = ">=2.2,<2.3" },
     { name = "optuna", specifier = ">=4.2.0,<5" },
     { name = "pandas", specifier = ">=2.2,<3.0" },
@@ -2887,12 +2916,14 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.9.0,<1.10" },
     { name = "scipy", specifier = ">=1.11.1,<2" },
     { name = "seaborn", marker = "extra == 'report'", specifier = ">=0.13.2,<0.14" },
+    { name = "tabicl", extras = ["shap"], marker = "extra == 'tabicl'", specifier = ">=2.1.1" },
     { name = "tabpfn", marker = "extra == 'tabpfn'", specifier = "==8.2.0" },
+    { name = "torch", marker = "extra == 'tabicl'", specifier = ">=2.11.0,<3" },
     { name = "torch", marker = "extra == 'tabpfn'", specifier = ">=2.3.0,<3" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.3.0,<3" },
     { name = "umap-learn", marker = "extra == 'report'", specifier = ">=0.5.12,<0.6" },
 ]
-provides-extras = ["torch", "report", "rna", "clustering", "tabpfn"]
+provides-extras = ["torch", "report", "rna", "clustering", "tabpfn", "tabicl"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5238,6 +5269,69 @@ wheels = [
 ]
 
 [[package]]
+name = "shapiq"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "colour" },
+    { name = "galois" },
+    { name = "joblib" },
+    { name = "matplotlib" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "sparse-transform" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/20/8e7bf8e1d2ad5e50c5ddb884760fe67657eee38b0ebe9d9996a0ab227221/shapiq-1.4.1.tar.gz", hash = "sha256:7f612c84fcfe4746ff826db72efa2944f9aa693c5c00c6e17a882613471534f8", size = 5781786, upload-time = "2025-11-10T19:43:31.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/cc/13fefd7203ffe71d5107221be939dd64945378b93f7c0a7cb82d7f281071/shapiq-1.4.1-py3-none-any.whl", hash = "sha256:c86667eb28ea0de56005fbe9fd072783242b74aa87fede11e07b6b915b93e7b3", size = 5871550, upload-time = "2025-11-10T19:43:29.858Z" },
+]
+
+[[package]]
+name = "shapiq"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "colour" },
+    { name = "joblib" },
+    { name = "matplotlib" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/55/6b12e99772dd45a90d6473afd16a1c6438da1ab4d91c6b9b81ac4e958088/shapiq-1.7.0.tar.gz", hash = "sha256:17cad036c50ec5782a4e72550ba5b1e73955b8f06387acb6e20d436eb33eb44d", size = 15318066, upload-time = "2026-08-27T13:10:59.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/4b/d2866469cd6fb1beed9cc2345173128fdd4a21670f73cf0e04197f504039/shapiq-1.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a29d2e83decaf1fc6b7a3344c774b9466fed486684b01d4777ae4c96404190b", size = 16164581, upload-time = "2026-08-27T13:10:31.132Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/f16b1a36869135d2512bf050cec1f1e0070ed12e849ddcca8802fb30ac5c/shapiq-1.7.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2a97f078678672655391a62638060fbdc1129a6095e81fbbe9e5ba088b05a2a6", size = 16147370, upload-time = "2026-08-27T13:10:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fd/c5e31e17e6fb09c376e997c996c60b6008bd64d0fbb348b597af98ab48a7/shapiq-1.7.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc2e556f5b3a9c5e3f55f402f1e43276917e4228ba21a97f104dea0d8cc8c9e5", size = 17928337, upload-time = "2026-08-27T13:10:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/41/42/560dc3a2a3627200ddfe8ded67ca79e7adf7426f5e1b21b627ce2b68055e/shapiq-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:474ead88733724319fe016ba5d670200e23c3796b813feacfde8be553900d956", size = 16043784, upload-time = "2026-08-27T13:10:38.129Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/36/c5e3f6f52012367c80f5d36d4a2b2611986af08b5dd50c87be24306fc483/shapiq-1.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a3e00c0b0a3d3ee01ff8334926329bbbb1b8f8d9cabe81f1a5f16e622efe9a91", size = 16164596, upload-time = "2026-08-27T13:10:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/17/4cde51ee3c819f456a63824c56effa73cc419441b5711d0444b599e3c34e/shapiq-1.7.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:870f622f3c4962b56046babcbda9b8f36b32ae59b9e8413993fc9b646128a3dd", size = 16147373, upload-time = "2026-08-27T13:10:43.429Z" },
+    { url = "https://files.pythonhosted.org/packages/18/17/3b890f3adf731725467c93f1becfef19bdcaaa5194a2bb651f0e3061991a/shapiq-1.7.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ba078726fa6401278d83c8fd4ad8fa28cc851374c5cc56aa2890984c6022441", size = 17940714, upload-time = "2026-08-27T13:10:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e6/f609f790273ae06fb97d19d3b1e834baff7569f878ca6ab8bfcc7e61ba7a/shapiq-1.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:adb39eaa225d8cd50aee7cee5153e0c3baa4fdf7b43f1c396540a17381de7409", size = 16043797, upload-time = "2026-08-27T13:10:48.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/96/7182581836dc98d18a8813e5e0565887c05ba7e92b7ce4301677336c6cdb/shapiq-1.7.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a5db3f3587ba581e521c5e6e8a4c46634da194885c4dc93fcafab7dcd3345fc", size = 16164721, upload-time = "2026-08-27T13:10:50.552Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3d/c1978dac495effbfec4fff4490ade240f12506ad2ac5871a432173be2083/shapiq-1.7.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:d50e2c21cf7b15a9040d0e7da7505e4754ca32ea9b0564dbbeab49f6add2a223", size = 16147558, upload-time = "2026-08-27T13:10:53.048Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/87/e35d493374eb2d9a54b49fdd120f651f9e29bcc3102a82c30cebb0da9e05/shapiq-1.7.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:116ac5797692d5b687fa4bafed32a0149612aefdb3b1e0c5f3057f953ce916db", size = 17941056, upload-time = "2026-08-27T13:10:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a2/5d004323f1027f0ca176e2340492aa3d0d3eced8730af8667ff057de559e/shapiq-1.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7fce0912d865eb3d793b1f6f1171b96c9e4df3b83476dcf8ee7bca1709bc6881", size = 15928709, upload-time = "2026-08-27T13:10:57.563Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5280,6 +5374,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/80/f1/93422647dd7e461f23d254e6b2bfa687a85b53aeb4903fcdbb74474d4584/soupsieve-2.9.tar.gz", hash = "sha256:acee8417325c5653e1377dc31eccad59eb82cbc65942afe6174c53b3aaad63fc", size = 122122, upload-time = "2026-07-19T01:35:18.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/d6/3185ab5ad1280319b31986898f3206dd7227cd75e293d4dba2a5e6bf27a0/soupsieve-2.9-py3-none-any.whl", hash = "sha256:a2b2c76d67df2382d245409fd71e321a571717e58463efa32ace87dcadac2c12", size = 37387, upload-time = "2026-07-19T01:35:17.106Z" },
+]
+
+[[package]]
+name = "sparse-transform"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "galois" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/da/82132137fdc207c4a14abb52fedcd8cc3dd697175f548cfb8689bd2afab8/sparse_transform-0.2.1.tar.gz", hash = "sha256:470d54c884600d97254469a3d85fac775480d18a8aa2c43574350695e1015c66", size = 24803, upload-time = "2025-04-03T08:11:39.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ec/c85f95289e4638faf889ca02b588ad3af0f3ef8f92b99bee3ce936ef3860/sparse_transform-0.2.1-py3-none-any.whl", hash = "sha256:d01b19f8add68e2b4c98a17272830af0e03d163667f03b1dc2b0c9eb8471727b", size = 27034, upload-time = "2025-04-03T08:11:38.551Z" },
 ]
 
 [[package]]
@@ -5394,6 +5504,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabicl"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "einops" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "psutil" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/c3/ef8bcc7645bc1eedae4563df6429f6f5438aaea5e293682a9367bf2c2ddb/tabicl-2.1.1.tar.gz", hash = "sha256:7abdb1fa878e7a1edfa1c6606bf4189e9cccc20935e8011d7e690f4693c9c5c5", size = 224680, upload-time = "2026-04-29T15:57:46.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/d3/f6eadcef58322b1b0253df1c17d9230db9934274f52e0d952458f6c6ab41/tabicl-2.1.1-py3-none-any.whl", hash = "sha256:cb4405cc93335c688bc9bcb703c7944032fcf542b43ebb66820f1a5acb5651b1", size = 252909, upload-time = "2026-04-29T15:57:47.775Z" },
+]
+
+[package.optional-dependencies]
+shap = [
+    { name = "matplotlib" },
+    { name = "numba" },
+    { name = "shap" },
+    { name = "shapiq", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "shapiq", version = "1.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/Bayer-Group/MotherML/blob/main/src/mother/feature_generation/core.py https://github.com/Bayer-Group/MotherML/blob/main/src/mother/feature_generation/config.py currently the Morgan Fingeprint setting in Mother is to not use counts. Binary fingerprints are usually not a good choice for ML, so should make sure that the standard setting is to use counts. This also enables better treatment in the case of bit colission, , as they at least increase the count by +1 instead od just ignoring. And maybe increase fpsize to 2048 in core.py too asis already in the config. Most users will not change on their own, and for some tasks using binary FP can make models perform substantially worse, which is also backed by literature: [Count-Based Morgan Fingerprint: A More Efficient and Interpretable Molecular Representation in Deve…](https://pubs.acs.org/esthag/article-abstract/57/46/18193/882899/Count-Based-Morgan-Fingerprint-A-More-Efficient?redirectedFrom=fulltext) [Count your bits: fingerprint benchmarking to assess broad chemical space representation | Journal o…](https://link.springer.com/article/10.1186/s13321-026-01245-y)